### PR TITLE
Don't strip surrogate pairs (emoji, etc.)

### DIFF
--- a/Solutions/Argotic.Common/SyndicationEncodingUtility.cs
+++ b/Solutions/Argotic.Common/SyndicationEncodingUtility.cs
@@ -6,7 +6,9 @@ using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
+using System.Xml;
 using System.Xml.XPath;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Argotic.Common
 {
@@ -568,11 +570,24 @@ namespace Argotic.Common
         /// <exception cref="ArgumentNullException">The <paramref name="content"/> is an empty string.</exception>
         public static string RemoveInvalidXmlHexadecimalCharacters(string content)
         {
-            Regex invalidXmlHexadecimalCharacters = new Regex(@"[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD]");
-
             Guard.ArgumentNotNullOrEmptyString(content, "content");
 
-            return invalidXmlHexadecimalCharacters.Replace(content, String.Empty);
+            StringBuilder result = new StringBuilder(content.Length);
+            for (int i = 0; i < content.Length; i++)
+            {
+                if (XmlConvert.IsXmlChar(content[i]))
+                {
+                    result.Append(content[i]);
+                }
+                else if (i + 1 < content.Length && XmlConvert.IsXmlSurrogatePair(content[i + 1], content[i]))
+                {
+                    result.Append(content[i]);
+                    result.Append(content[i + 1]);
+                    i++;
+                }
+            }
+
+            return result.ToString();
         }
 
         /// <summary>

--- a/Solutions/Argotic.Common/SyndicationEncodingUtility.cs
+++ b/Solutions/Argotic.Common/SyndicationEncodingUtility.cs
@@ -572,6 +572,7 @@ namespace Argotic.Common
         {
             Guard.ArgumentNotNullOrEmptyString(content, "content");
 
+            // Adapted from https://stackoverflow.com/a/17735649
             StringBuilder result = new StringBuilder(content.Length);
             for (int i = 0; i < content.Length; i++)
             {

--- a/Solutions/Argotic.Common/SyndicationEncodingUtility.cs
+++ b/Solutions/Argotic.Common/SyndicationEncodingUtility.cs
@@ -5,10 +5,8 @@ using System.IO.Compression;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Web;
 using System.Xml;
 using System.Xml.XPath;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Argotic.Common
 {

--- a/Solutions/Argotic.Extensions.Tests/Functionality/Common/SyndicationEncodingUtilityTest.cs
+++ b/Solutions/Argotic.Extensions.Tests/Functionality/Common/SyndicationEncodingUtilityTest.cs
@@ -1,0 +1,26 @@
+﻿namespace Argotic.Extensions.Tests
+{
+    using Argotic.Common;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// This is a test class for SyndicationEncodingUtilityTest and is intended
+    /// to contain all SyndicationEncodingUtilityTest Unit Tests
+    /// </summary>
+    [TestClass()]
+    public class SyndicationEncodingUtilityTest
+    {
+        /// <summary>
+        /// A test for RemoveInvalidXmlHexadecimalCharacters
+        /// </summary>
+        [TestMethod]
+        [DataRow("a", "a")]
+        [DataRow("@±あ😀", "@±あ😀")] // Emoji should not be stripped
+        [DataRow("a\uFFFEb", "ab")] // FFFE should be stripped
+        public void RemoveInvalidXmlHexadecimalCharactersTest(string input, string expected)
+        {
+            var stripped = SyndicationEncodingUtility.RemoveInvalidXmlHexadecimalCharacters(input);
+            Assert.AreEqual(expected, stripped);
+        }
+    }
+}


### PR DESCRIPTION
The `RemoveInvalidXmlHexadecimalCharacters` method currently strips surrogate pairs (two 16-bit code units), which means most emoji and some non-Latin scripts are removed.

This change stops valid surrogate pairs from being stripped and adds some test cases.