### PR TITLE
Write sitemap dates in UTC with Z and add opt-in xsi:schemaLocation output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,34 @@ Entries that start with **BREAKING** change behaviour or an API that callers use
 
 ## [Unreleased]
 
-The .NET 10 release. The version changes from 3001.0.0 to 4000.0.0.
+The next release is 4000.0.2.
+
+### Added
+
+- **`SyndicationResourceSaveSettings.WriteXsiSchemaLocation`.** This opt-in setting makes `Sitemap.Save`
+  and `SitemapIndex.Save` write the `xmlns:xsi` declaration and the `xsi:schemaLocation` attribute on
+  the root element. The default value is `false`, and the default output does not change. A `urlset`
+  root pairs the core namespace with `sitemap.xsd`. A `sitemapindex` root pairs the same namespace with
+  `siteindex.xsd`. One more pair follows for each declared extension namespace with a published schema:
+  news, image and video. A namespace with no known schema location is skipped, such as the `xhtml`
+  namespace of the hreflang extension. Consumers that validate a sitemap use the attribute as a
+  validation hint. (Issue 177.)
+
+### Fixed
+
+- **Sitemap extension dates write in UTC, with the `Z` designator.** `news:publication_date`,
+  `video:publication_date` and `video:expiration_date` normalise their value to UTC before the format
+  step. A `Local` kind converts to the same instant. An `Unspecified` kind is a claim of UTC and keeps
+  its wall clock. Before, the format specifier `zzz` stamped the offset of the host machine on a `Local`
+  or `Unspecified` wall clock. The load path assumes UTC, and thus an `Unspecified` value written on a
+  non-UTC host came back as a different instant. A `Utc` kind was safe on each host, but it wrote the
+  non-canonical form `+00:00`. The output is now identical on every machine. (Issue 177.)
+
+## [4000.0.1] - 2026-08-10
+
+The .NET 10 release. The version changes from 3001.0.0 to 4000.0.1. The tag `4000.0.0` exists, but its
+NuGet publication failed in CI. `4000.0.1` is the shipped package, and it has no library change on top
+of `4000.0.0`.
 
 ### Added
 
@@ -82,14 +109,6 @@ The .NET 10 release. The version changes from 3001.0.0 to 4000.0.0.
   use the API.
 - **`HashCodeUtility`.** This helper makes hash code components that agree with the case-insensitive
   comparison rules of the framework.
-- **`SyndicationResourceSaveSettings.WriteXsiSchemaLocation`.** This opt-in setting makes `Sitemap.Save`
-  and `SitemapIndex.Save` write the `xmlns:xsi` declaration and the `xsi:schemaLocation` attribute on
-  the root element. The default value is `false`, and the default output does not change. A `urlset`
-  root pairs the core namespace with `sitemap.xsd`. A `sitemapindex` root pairs the same namespace with
-  `siteindex.xsd`. One more pair follows for each declared extension namespace with a published schema:
-  news, image and video. A namespace with no known schema location is skipped, such as the `xhtml`
-  namespace of the hreflang extension. Consumers that validate a sitemap use the attribute as a
-  validation hint. (Issue 177.)
 
 ### Changed
 
@@ -378,13 +397,6 @@ The changes in this group fix no defect and break no documented contract. A call
 - **`RetrievalLimit`.** `Sitemap` and `SitemapIndex` obey
   `SyndicationResourceLoadSettings.RetrievalLimit` on their public load paths. Before, they read each
   entry and ignored the limit.
-- **Extension dates write in UTC, with the `Z` designator.** `news:publication_date`,
-  `video:publication_date` and `video:expiration_date` normalise their value to UTC before the format
-  step. A `Local` kind converts to the same instant. An `Unspecified` kind is a claim of UTC and keeps
-  its wall clock. Before, the format specifier `zzz` stamped the offset of the host machine on a `Local`
-  or `Unspecified` wall clock. The load path assumes UTC, and thus an `Unspecified` value written on a
-  non-UTC host came back as a different instant. A `Utc` kind was safe on each host, but it wrote the
-  non-canonical form `+00:00`. The output is now identical on every machine. (Issue 177.)
 
 #### Atom Publishing
 
@@ -442,5 +454,6 @@ The changes in this group fix no defect and break no documented contract. A call
   parser reads the internal DTD subset, and does not ignore it. Thus a feed that declares its own
   entities loads correctly, and the external-entity vector stays closed.
 
-[Unreleased]: https://github.com/argotic-syndication-framework/Argotic/compare/3001.0.0...HEAD
+[Unreleased]: https://github.com/argotic-syndication-framework/Argotic/compare/4000.0.1...HEAD
+[4000.0.1]: https://github.com/argotic-syndication-framework/Argotic/compare/3001.0.0...4000.0.1
 [3001.0.0]: https://github.com/argotic-syndication-framework/Argotic/releases/tag/3001.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ The .NET 10 release. The version changes from 3001.0.0 to 4000.0.0.
   use the API.
 - **`HashCodeUtility`.** This helper makes hash code components that agree with the case-insensitive
   comparison rules of the framework.
+- **`SyndicationResourceSaveSettings.WriteXsiSchemaLocation`.** This opt-in setting makes `Sitemap.Save`
+  and `SitemapIndex.Save` write the `xmlns:xsi` declaration and the `xsi:schemaLocation` attribute on
+  the root element. The default value is `false`, and the default output does not change. A `urlset`
+  root pairs the core namespace with `sitemap.xsd`. A `sitemapindex` root pairs the same namespace with
+  `siteindex.xsd`. One more pair follows for each declared extension namespace with a published schema:
+  news, image and video. A namespace with no known schema location is skipped, such as the `xhtml`
+  namespace of the hreflang extension. Consumers that validate a sitemap use the attribute as a
+  validation hint. (Issue 177.)
 
 ### Changed
 
@@ -370,6 +378,13 @@ The changes in this group fix no defect and break no documented contract. A call
 - **`RetrievalLimit`.** `Sitemap` and `SitemapIndex` obey
   `SyndicationResourceLoadSettings.RetrievalLimit` on their public load paths. Before, they read each
   entry and ignored the limit.
+- **Extension dates write in UTC, with the `Z` designator.** `news:publication_date`,
+  `video:publication_date` and `video:expiration_date` normalise their value to UTC before the format
+  step. A `Local` kind converts to the same instant. An `Unspecified` kind is a claim of UTC and keeps
+  its wall clock. Before, the format specifier `zzz` stamped the offset of the host machine on a `Local`
+  or `Unspecified` wall clock. The load path assumes UTC, and thus an `Unspecified` value written on a
+  non-UTC host came back as a different instant. A `Utc` kind was safe on each host, but it wrote the
+  non-canonical form `+00:00`. The output is now identical on every machine. (Issue 177.)
 
 #### Atom Publishing
 

--- a/Solutions/Argotic.Common/SyndicationResourceSaveSettings.cs
+++ b/Solutions/Argotic.Common/SyndicationResourceSaveSettings.cs
@@ -83,10 +83,37 @@ public sealed class SyndicationResourceSaveSettings : IComparable<SyndicationRes
     public IList<Type> SupportedExtensions => supportedSyndicationExtensions ??= [];
 
     /// <summary>
+    /// Gets or sets a value indicating if the save operation writes an <c>xsi:schemaLocation</c> attribute on the root element.
+    /// </summary>
+    /// <value>
+    ///     <see langword="true"/> to write the <c>xmlns:xsi</c> declaration and the <c>xsi:schemaLocation</c> attribute; otherwise, <see langword="false"/>.
+    ///     The default value is <see langword="false"/>.
+    /// </value>
+    /// <remarks>
+    ///     <para>
+    ///     Only the sitemap resource types honour this option. A <c>urlset</c> root pairs the core
+    ///     namespace with <c>sitemap.xsd</c>; a <c>sitemapindex</c> root pairs the same namespace with
+    ///     <c>siteindex.xsd</c>. One more pair is written for each declared extension namespace with a
+    ///     known schema location: the Google news, image and video extensions. A namespace with no
+    ///     known schema location is skipped — the hreflang extension's <c>xhtml</c> namespace, and any
+    ///     consumer-supplied extension. Every other resource type ignores the option, as
+    ///     <see cref="AutoDetectExtensions"/> is likewise meaningful only where extensions exist.
+    ///     </para>
+    ///     <para>
+    ///     The attribute is a validation hint, nothing more. A consumer that validates supplies its
+    ///     own schema set; this library's own conformance checks never read the attribute. An
+    ///     extension that claims the <c>xsi</c> prefix for another namespace makes the save throw
+    ///     <see cref="System.Xml.XmlException"/> on the duplicate declaration, exactly as two
+    ///     extensions sharing a prefix across different namespaces already do.
+    ///     </para>
+    /// </remarks>
+    public bool WriteXsiSchemaLocation { get; set; }
+
+    /// <summary>
     /// Returns a <see cref="string"/> that represents the current <see cref="SyndicationResourceSaveSettings"/>.
     /// </summary>
     /// <returns>The settings, with <see cref="SupportedExtensions"/> reduced to its hash code rather than enumerated.</returns>
-    public override string ToString() => $"[SyndicationResourceSaveSettings(CharacterEncoding = \"{this.CharacterEncoding.WebName}\", MinimizeOutputSize = \"{this.MinimizeOutputSize}\", Autodetect = \"{this.AutoDetectExtensions}\", SupportedExtensions = \"{this.SupportedExtensions.GetHashCode().ToString(System.Globalization.NumberFormatInfo.InvariantInfo)}\")]";
+    public override string ToString() => $"[SyndicationResourceSaveSettings(CharacterEncoding = \"{this.CharacterEncoding.WebName}\", MinimizeOutputSize = \"{this.MinimizeOutputSize}\", Autodetect = \"{this.AutoDetectExtensions}\", SupportedExtensions = \"{this.SupportedExtensions.GetHashCode().ToString(System.Globalization.NumberFormatInfo.InvariantInfo)}\", WriteXsiSchemaLocation = \"{this.WriteXsiSchemaLocation}\")]";
 
     /// <summary>
     /// Compares the current instance with another object of the same type.
@@ -104,6 +131,7 @@ public sealed class SyndicationResourceSaveSettings : IComparable<SyndicationRes
         if (result == 0) result = this.MinimizeOutputSize.CompareTo(other.MinimizeOutputSize);
         if (result == 0) result = ComparisonUtility.CompareSequence(this.SupportedExtensions, other.SupportedExtensions);
         if (result == 0) result = this.AutoDetectExtensions.CompareTo(other.AutoDetectExtensions);
+        if (result == 0) result = this.WriteXsiSchemaLocation.CompareTo(other.WriteXsiSchemaLocation);
 
         return result;
     }
@@ -140,6 +168,7 @@ public sealed class SyndicationResourceSaveSettings : IComparable<SyndicationRes
         hash.Add(HashCodeUtility.Component(this.CharacterEncoding?.WebName));
         hash.Add(HashCodeUtility.Component(this.MinimizeOutputSize));
         hash.Add(HashCodeUtility.Component(this.AutoDetectExtensions));
+        hash.Add(HashCodeUtility.Component(this.WriteXsiSchemaLocation));
         var extensions = this.supportedSyndicationExtensions;
         if (extensions is not null)
         {

--- a/Solutions/Argotic.Core/Syndication/Sitemap/Sitemap.cs
+++ b/Solutions/Argotic.Core/Syndication/Sitemap/Sitemap.cs
@@ -385,6 +385,12 @@ public class Sitemap : ISyndicationResource, IExtensibleSyndicationObject
         }
 
         SyndicationExtensionAdapter.WriteXmlNamespaceDeclarations(settings.SupportedExtensions, writer);
+
+        if (settings.WriteXsiSchemaLocation)
+        {
+            SitemapSchemaLocations.WriteXsiSchemaLocation(writer, SitemapSchemaLocations.SitemapXsd, settings.SupportedExtensions);
+        }
+
         SyndicationExtensionAdapter.WriteExtensionsTo(this.Extensions, writer);
 
         foreach (SitemapUrl url in this.Urls)

--- a/Solutions/Argotic.Core/Syndication/Sitemap/SitemapIndex.cs
+++ b/Solutions/Argotic.Core/Syndication/Sitemap/SitemapIndex.cs
@@ -373,6 +373,12 @@ public class SitemapIndex : ISyndicationResource, IExtensibleSyndicationObject
         }
 
         SyndicationExtensionAdapter.WriteXmlNamespaceDeclarations(settings.SupportedExtensions, writer);
+
+        if (settings.WriteXsiSchemaLocation)
+        {
+            SitemapSchemaLocations.WriteXsiSchemaLocation(writer, SitemapSchemaLocations.SiteindexXsd, settings.SupportedExtensions);
+        }
+
         SyndicationExtensionAdapter.WriteExtensionsTo(this.Extensions, writer);
 
         foreach (SitemapIndexEntry entry in this.Sitemaps)

--- a/Solutions/Argotic.Core/Syndication/Sitemap/SitemapSchemaLocations.cs
+++ b/Solutions/Argotic.Core/Syndication/Sitemap/SitemapSchemaLocations.cs
@@ -1,0 +1,77 @@
+using System.Xml;
+
+using Argotic.Extensions;
+
+namespace Argotic.Syndication;
+
+/// <summary>
+/// Writes the opt-in <c>xsi:schemaLocation</c> attribute for the two sitemap roots.
+/// </summary>
+/// <remarks>
+///     <para>
+///     The core pair is root-dependent, not namespace-dependent: <c>urlset</c> and
+///     <c>sitemapindex</c> share one namespace but validate against different schemas. The caller
+///     passes its root's schema, <see cref="SitemapXsd"/> or <see cref="SiteindexXsd"/>.
+///     </para>
+///     <para>
+///     A pair is written only for a namespace with a known, published schema. The hreflang
+///     extension's <c>xhtml</c> namespace has none, and a consumer-supplied extension's schema is
+///     unknowable, so both are skipped. The attribute is a hint; a partial list is valid.
+///     </para>
+/// </remarks>
+internal static class SitemapSchemaLocations
+{
+    /// <summary>The schema location for a <c>urlset</c> root.</summary>
+    public const string SitemapXsd = "http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd";
+
+    /// <summary>The schema location for a <c>sitemapindex</c> root.</summary>
+    public const string SiteindexXsd = "http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd";
+
+    private const string XsiNamespace = "http://www.w3.org/2001/XMLSchema-instance";
+
+    /// <summary>
+    /// The extension namespaces with a published schema, keyed by namespace URI.
+    /// </summary>
+    /// <remarks>
+    ///     The keys match the constructor literals in <c>SitemapNewsExtension</c>,
+    ///     <c>SitemapImageExtension</c> and <c>SitemapVideoExtension</c>. Both columns keep the
+    ///     <c>http</c> scheme: the namespaces are identifiers, and the schema locations are the
+    ///     spellings the protocol's own examples use. The integration tier fetches the same three
+    ///     files over <c>https</c>; see <c>LiveSchemaSource</c> in the test project.
+    /// </remarks>
+    private static readonly Dictionary<string, string> ExtensionSchemas = new(StringComparer.Ordinal)
+    {
+        ["http://www.google.com/schemas/sitemap-news/0.9"] = "http://www.google.com/schemas/sitemap-news/0.9/sitemap-news.xsd",
+        ["http://www.google.com/schemas/sitemap-image/1.1"] = "http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd",
+        ["http://www.google.com/schemas/sitemap-video/1.1"] = "http://www.google.com/schemas/sitemap-video/1.1/sitemap-video.xsd",
+    };
+
+    /// <summary>
+    /// Writes the <c>xmlns:xsi</c> declaration and the <c>xsi:schemaLocation</c> attribute on the root element.
+    /// </summary>
+    /// <param name="writer">The writer whose root start tag is still open.</param>
+    /// <param name="rootSchemaLocation">The root's own schema: <see cref="SitemapXsd"/> or <see cref="SiteindexXsd"/>.</param>
+    /// <param name="supportedExtensions">The extension types to pair, after auto-detection has merged into them.</param>
+    /// <remarks>
+    ///     The pair order is deterministic: the core pair first, then extensions in list order,
+    ///     de-duplicated by namespace URI. The single <c>WriteAttributeString</c> call makes the
+    ///     writer emit the <c>xmlns:xsi</c> declaration itself.
+    /// </remarks>
+    public static void WriteXsiSchemaLocation(XmlWriter writer, string rootSchemaLocation, IList<Type> supportedExtensions)
+    {
+        List<string> tokens = [SitemapUtility.SitemapNamespace, rootSchemaLocation];
+        HashSet<string> seen = new(StringComparer.Ordinal) { SitemapUtility.SitemapNamespace };
+
+        foreach (ISyndicationExtension extension in SyndicationExtensionAdapter.GetExtensions(supportedExtensions))
+        {
+            if (ExtensionSchemas.TryGetValue(extension.XmlNamespace, out string? schemaLocation)
+                && seen.Add(extension.XmlNamespace))
+            {
+                tokens.Add(extension.XmlNamespace);
+                tokens.Add(schemaLocation);
+            }
+        }
+
+        writer.WriteAttributeString("xsi", "schemaLocation", XsiNamespace, string.Join(' ', tokens));
+    }
+}

--- a/Solutions/Argotic.Extensions.Tests/Functionality/Common/SaveSettingsSchemaLocationTests.cs
+++ b/Solutions/Argotic.Extensions.Tests/Functionality/Common/SaveSettingsSchemaLocationTests.cs
@@ -1,0 +1,52 @@
+namespace Argotic.Extensions.Tests.Functionality.Common;
+
+/// <summary>
+/// Pins the value semantics of <see cref="SyndicationResourceSaveSettings.WriteXsiSchemaLocation"/>.
+/// </summary>
+/// <remarks>
+///     <c>CompareTo</c>, <c>GetHashCode</c> and <c>ToString</c> enumerate the settings properties by
+///     hand. A property that is not threaded through them makes two settings that differ compare
+///     equal, silently. These pins fail if the threading is removed.
+/// </remarks>
+[TestClass]
+public class SaveSettingsSchemaLocationTests
+{
+    /// <summary>
+    /// Two settings that differ only in the schemaLocation option are not equal.
+    /// </summary>
+    [TestMethod]
+    public void TwoSettingsDifferingOnlyInWriteXsiSchemaLocation_AreNotEqual()
+    {
+        SyndicationResourceSaveSettings off = new();
+        SyndicationResourceSaveSettings on = new() { WriteXsiSchemaLocation = true };
+
+        off.Equals(on).ShouldBeFalse("the option is not threaded through CompareTo");
+        (off == on).ShouldBeFalse();
+        off.CompareTo(on).ShouldBeLessThan(0);
+        on.CompareTo(off).ShouldBeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// The option participates in the hash code.
+    /// </summary>
+    [TestMethod]
+    public void TheOption_ParticipatesInTheHashCode()
+    {
+        SyndicationResourceSaveSettings off = new();
+        SyndicationResourceSaveSettings on = new() { WriteXsiSchemaLocation = true };
+
+        on.GetHashCode().ShouldBe(new SyndicationResourceSaveSettings { WriteXsiSchemaLocation = true }.GetHashCode(), "equal settings must agree on the hash");
+        on.GetHashCode().ShouldNotBe(off.GetHashCode(), "the option is not hashed, so unequal settings collide by construction");
+    }
+
+    /// <summary>
+    /// The option appears in the diagnostic string.
+    /// </summary>
+    [TestMethod]
+    public void TheOption_AppearsInToString()
+    {
+        new SyndicationResourceSaveSettings { WriteXsiSchemaLocation = true }
+            .ToString()
+            .ShouldContain("WriteXsiSchemaLocation = \"True\"");
+    }
+}

--- a/Solutions/Argotic.Extensions.Tests/Functionality/Core/Sitemap/SitemapExtensionDateWritingTests.cs
+++ b/Solutions/Argotic.Extensions.Tests/Functionality/Core/Sitemap/SitemapExtensionDateWritingTests.cs
@@ -1,0 +1,208 @@
+namespace Argotic.Extensions.Tests.Functionality.Core.Sitemap;
+
+/// <summary>
+/// The news and video extensions write their dates in UTC, with the literal <c>Z</c> designator.
+/// </summary>
+/// <remarks>
+///     <para>
+///     These writers used the format string <c>yyyy-MM-ddTHH:mm:sszzz</c>. On .NET 10, <c>zzz</c>
+///     writes <c>+00:00</c> for a <c>Utc</c> kind on every machine — the runtime special-cases the
+///     kind — but it stamps the <b>machine's</b> offset on a <c>Local</c> or <c>Unspecified</c> wall
+///     clock. The load paths assume UTC for offset-less input, so an <c>Unspecified</c> value written
+///     on a non-UTC machine came back as a different instant. Issue 177 records the agreed fix: every
+///     kind is normalised to UTC and written with <c>Z</c>.
+///     </para>
+///     <para>
+///     The exact-text assertions are not vacuous on a UTC build agent: <c>zzz</c> renders
+///     <c>+00:00</c>, never <c>Z</c>, so the old shape differs from the required one whatever the
+///     machine's timezone. The <c>Local</c>-kind tests assert shape and round-trip instant only,
+///     because the exact text of a converted local wall clock is machine-dependent by construction.
+///     </para>
+/// </remarks>
+[TestClass]
+public class SitemapExtensionDateWritingTests
+{
+    /// <summary>
+    /// A news publication date of Utc or Unspecified kind keeps its wall clock and gains the Z designator.
+    /// </summary>
+    /// <param name="kind">The kind under test. Both kinds mean UTC to this library.</param>
+    [TestMethod]
+    [DataRow(DateTimeKind.Utc)]
+    [DataRow(DateTimeKind.Unspecified)]
+    public void AUtcOrUnspecifiedKindNewsPublicationDate_IsWrittenWithALiteralZ(DateTimeKind kind)
+    {
+        Syndication.Sitemap sitemap = SitemapWithNews(new DateTime(2026, 8, 7, 9, 0, 0, kind));
+
+        string xml = Save(sitemap);
+
+        xml.ShouldContain(
+            "<news:publication_date>2026-08-07T09:00:00Z</news:publication_date>",
+            customMessage: "the writer must not shift the wall clock and must use the Z designator");
+        xml.ShouldNotContain("+00:00", Case.Sensitive);
+        xml.ShouldNotContain("-00:00", Case.Sensitive);
+    }
+
+    /// <summary>
+    /// A news publication date of Local kind converts to UTC, writes with Z, and keeps its instant.
+    /// </summary>
+    [TestMethod]
+    public void ALocalKindNewsPublicationDate_IsWrittenAsUtcWithALiteralZ()
+    {
+        DateTime local = new(2026, 8, 7, 9, 0, 0, DateTimeKind.Local);
+        Syndication.Sitemap sitemap = SitemapWithNews(local);
+
+        string xml = Save(sitemap);
+
+        xml.ShouldContain("Z</news:publication_date>", Case.Sensitive);
+        xml.ShouldNotContain("+00:00", Case.Sensitive);
+        xml.ShouldNotContain("-00:00", Case.Sensitive);
+
+        SitemapNewsExtension read = Reload(sitemap).Urls[0].Extensions.OfType<SitemapNewsExtension>()
+            .Single();
+        read.PublicationDate.ShouldBe(
+            local.ToUniversalTime(),
+            "a Local kind must convert to the same instant in UTC, on any machine");
+    }
+
+    /// <summary>
+    /// A video publication date of Utc or Unspecified kind keeps its wall clock and gains the Z designator.
+    /// </summary>
+    /// <param name="kind">The kind under test. Both kinds mean UTC to this library.</param>
+    [TestMethod]
+    [DataRow(DateTimeKind.Utc)]
+    [DataRow(DateTimeKind.Unspecified)]
+    public void AUtcOrUnspecifiedKindVideoPublicationDate_IsWrittenWithALiteralZ(DateTimeKind kind)
+    {
+        Syndication.Sitemap sitemap = SitemapWithVideo(video =>
+            video.PublicationDate = new DateTime(2026, 8, 7, 9, 0, 0, kind));
+
+        string xml = Save(sitemap);
+
+        xml.ShouldContain(
+            "<video:publication_date>2026-08-07T09:00:00Z</video:publication_date>",
+            customMessage: "the writer must not shift the wall clock and must use the Z designator");
+        xml.ShouldNotContain("+00:00", Case.Sensitive);
+        xml.ShouldNotContain("-00:00", Case.Sensitive);
+    }
+
+    /// <summary>
+    /// A video publication date of Local kind converts to UTC, writes with Z, and keeps its instant.
+    /// </summary>
+    [TestMethod]
+    public void ALocalKindVideoPublicationDate_IsWrittenAsUtcWithALiteralZ()
+    {
+        DateTime local = new(2026, 8, 7, 9, 0, 0, DateTimeKind.Local);
+        Syndication.Sitemap sitemap = SitemapWithVideo(video => video.PublicationDate = local);
+
+        string xml = Save(sitemap);
+
+        xml.ShouldContain("Z</video:publication_date>", Case.Sensitive);
+        xml.ShouldNotContain("+00:00", Case.Sensitive);
+        xml.ShouldNotContain("-00:00", Case.Sensitive);
+
+        ReadVideo(sitemap).PublicationDate.ShouldBe(
+            local.ToUniversalTime(),
+            "a Local kind must convert to the same instant in UTC, on any machine");
+    }
+
+    /// <summary>
+    /// A video expiration date of Utc or Unspecified kind keeps its wall clock and gains the Z designator.
+    /// </summary>
+    /// <param name="kind">The kind under test. Both kinds mean UTC to this library.</param>
+    [TestMethod]
+    [DataRow(DateTimeKind.Utc)]
+    [DataRow(DateTimeKind.Unspecified)]
+    public void AUtcOrUnspecifiedKindVideoExpirationDate_IsWrittenWithALiteralZ(DateTimeKind kind)
+    {
+        Syndication.Sitemap sitemap = SitemapWithVideo(video =>
+            video.ExpirationDate = new DateTime(2026, 8, 7, 9, 0, 0, kind));
+
+        string xml = Save(sitemap);
+
+        xml.ShouldContain(
+            "<video:expiration_date>2026-08-07T09:00:00Z</video:expiration_date>",
+            customMessage: "the writer must not shift the wall clock and must use the Z designator");
+        xml.ShouldNotContain("+00:00", Case.Sensitive);
+        xml.ShouldNotContain("-00:00", Case.Sensitive);
+    }
+
+    /// <summary>
+    /// A video expiration date of Local kind converts to UTC, writes with Z, and keeps its instant.
+    /// </summary>
+    [TestMethod]
+    public void ALocalKindVideoExpirationDate_IsWrittenAsUtcWithALiteralZ()
+    {
+        DateTime local = new(2026, 8, 7, 9, 0, 0, DateTimeKind.Local);
+        Syndication.Sitemap sitemap = SitemapWithVideo(video => video.ExpirationDate = local);
+
+        string xml = Save(sitemap);
+
+        xml.ShouldContain("Z</video:expiration_date>", Case.Sensitive);
+        xml.ShouldNotContain("+00:00", Case.Sensitive);
+        xml.ShouldNotContain("-00:00", Case.Sensitive);
+
+        ReadVideo(sitemap).ExpirationDate.ShouldBe(
+            local.ToUniversalTime(),
+            "a Local kind must convert to the same instant in UTC, on any machine");
+    }
+
+    private static Syndication.Sitemap SitemapWithNews(DateTime publicationDate)
+    {
+        SitemapNewsExtension news = new()
+        {
+            Title = "A breaking story",
+            PublicationDate = publicationDate,
+            Publication = new SitemapNewsPublication { Name = "The Example Times", Language = "en" },
+        };
+
+        SitemapUrl url = new(new Uri("https://example.com/news/story"));
+        url.Extensions.Add(news);
+
+        Syndication.Sitemap sitemap = new();
+        sitemap.Urls.Add(url);
+        return sitemap;
+    }
+
+    private static Syndication.Sitemap SitemapWithVideo(Action<SitemapVideo> configure)
+    {
+        SitemapVideo video = new()
+        {
+            Title = "An example video",
+            Description = "A description of the example video",
+            ThumbnailLocation = new Uri("https://example.com/thumb.jpg"),
+            ContentLocation = new Uri("https://example.com/video.mp4"),
+        };
+        configure(video);
+
+        SitemapVideoExtension extension = new();
+        extension.Videos.Add(video);
+
+        SitemapUrl url = new(new Uri("https://example.com/watch/1"));
+        url.Extensions.Add(extension);
+
+        Syndication.Sitemap sitemap = new();
+        sitemap.Urls.Add(url);
+        return sitemap;
+    }
+
+    private static SitemapVideo ReadVideo(Syndication.Sitemap sitemap) =>
+        Reload(sitemap).Urls[0].Extensions.OfType<SitemapVideoExtension>().Single().Videos[0];
+
+    private static string Save(Syndication.Sitemap sitemap)
+    {
+        using MemoryStream stream = new();
+        sitemap.Save(stream);
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static Syndication.Sitemap Reload(Syndication.Sitemap sitemap)
+    {
+        using MemoryStream stream = new();
+        sitemap.Save(stream);
+        stream.Seek(0, SeekOrigin.Begin);
+
+        Syndication.Sitemap read = new();
+        read.Load(stream);
+        return read;
+    }
+}

--- a/Solutions/Argotic.Extensions.Tests/Functionality/Core/Sitemap/SitemapSchemaLocationTests.cs
+++ b/Solutions/Argotic.Extensions.Tests/Functionality/Core/Sitemap/SitemapSchemaLocationTests.cs
@@ -1,0 +1,289 @@
+namespace Argotic.Extensions.Tests.Functionality.Core.Sitemap;
+
+/// <summary>
+/// The opt-in <c>xsi:schemaLocation</c> output on the two sitemap roots.
+/// </summary>
+/// <remarks>
+///     <para>
+///     Issue 177: consumers that validate sitemaps against the XSD schemas want the attribute as a
+///     validation hint. The option lives on <see cref="SyndicationResourceSaveSettings"/>, defaults to
+///     off, and must not change the default output. A <c>urlset</c> root pairs the core namespace with
+///     <c>sitemap.xsd</c>; a <c>sitemapindex</c> root pairs the same namespace with
+///     <c>siteindex.xsd</c> — same namespace, different schema, so the root decides the pair.
+///     </para>
+///     <para>
+///     Pairs are written only for namespaces with a known schema location: the core namespace and the
+///     Google news, image and video extensions. The hreflang extension's <c>xhtml</c> namespace has no
+///     sitemap schema, so it is declared but not paired. The XSD locations keep the <c>http</c> scheme
+///     of the protocol's own examples; the integration tier fetches the same files over <c>https</c>.
+///     </para>
+///     <para>
+///     The conformance test here asserts the attribute is present before it validates. Without that,
+///     the test would pass against a writer that never wrote the attribute at all.
+///     </para>
+/// </remarks>
+[TestClass]
+public class SitemapSchemaLocationTests
+{
+    private const string XsiNamespace = "http://www.w3.org/2001/XMLSchema-instance";
+
+    private const string CorePair = "http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd";
+
+    private const string IndexPair = "http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd";
+
+    private const string NewsPair = "http://www.google.com/schemas/sitemap-news/0.9 http://www.google.com/schemas/sitemap-news/0.9/sitemap-news.xsd";
+
+    private const string ImagePair = "http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd";
+
+    private const string VideoPair = "http://www.google.com/schemas/sitemap-video/1.1 http://www.google.com/schemas/sitemap-video/1.1/sitemap-video.xsd";
+
+    /// <summary>
+    /// A plain sitemap saved with the option on declares xsi and writes the core pair.
+    /// </summary>
+    [TestMethod]
+    public void APlainSitemapWithTheOptionOn_WritesTheCoreSchemaLocationPair()
+    {
+        string xml = Save(PlainSitemap(), OptionOn());
+
+        xml.ShouldContain($"xmlns:xsi=\"{XsiNamespace}\"");
+        SchemaLocationValue(xml).ShouldBe(CorePair);
+    }
+
+    /// <summary>
+    /// A sitemap carrying news and image extensions writes three pairs, core first.
+    /// </summary>
+    [TestMethod]
+    public void ASitemapCarryingNewsAndImages_WritesThreePairs()
+    {
+        string xml = Save(SitemapWithNewsAndImages(), OptionOn());
+
+        SchemaLocationValue(xml).ShouldBe(
+            $"{CorePair} {NewsPair} {ImagePair}",
+            "the pairs must follow the extension declaration order, after the core pair");
+    }
+
+    /// <summary>
+    /// A sitemap carrying the video extension writes two pairs.
+    /// </summary>
+    [TestMethod]
+    public void ASitemapCarryingVideo_WritesTwoPairs()
+    {
+        string xml = Save(SitemapWithVideo(), OptionOn());
+
+        SchemaLocationValue(xml).ShouldBe($"{CorePair} {VideoPair}");
+    }
+
+    /// <summary>
+    /// An empty sitemap with pre-registered extensions writes the registered pairs.
+    /// </summary>
+    /// <remarks>
+    ///     Auto-detection finds nothing here — there are no urls — so the pair can come only from
+    ///     <see cref="SyndicationResourceSaveSettings.SupportedExtensions"/>.
+    /// </remarks>
+    [TestMethod]
+    public void AnEmptySitemapWithPreRegisteredExtensions_WritesTheRegisteredPairs()
+    {
+        SyndicationResourceSaveSettings settings = OptionOn();
+        settings.SupportedExtensions.Add(typeof(SitemapNewsExtension));
+
+        string xml = Save(new Syndication.Sitemap(), settings);
+
+        SchemaLocationValue(xml).ShouldBe($"{CorePair} {NewsPair}");
+    }
+
+    /// <summary>
+    /// The hreflang extension's xhtml namespace is declared but not paired.
+    /// </summary>
+    [TestMethod]
+    public void ASitemapCarryingHreflangAnnotations_SkipsTheXhtmlNamespace()
+    {
+        string xml = Save(SitemapWithHreflang(), OptionOn());
+
+        xml.ShouldContain(
+            "xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"",
+            customMessage: "the namespace declaration itself must not change");
+        SchemaLocationValue(xml).ShouldBe(
+            CorePair,
+            "no sitemap schema exists for the xhtml namespace, so it has no pair");
+    }
+
+    /// <summary>
+    /// A sitemap index saved with the option on pairs the namespace with siteindex.xsd, not sitemap.xsd.
+    /// </summary>
+    [TestMethod]
+    public void ASitemapIndexWithTheOptionOn_WritesTheSiteindexSchemaLocation()
+    {
+        SitemapIndex index = new();
+        index.Sitemaps.Add(new SitemapIndexEntry { Location = new Uri("https://example.com/sitemap.xml") });
+
+        string xml = Save(index, OptionOn());
+
+        xml.ShouldContain($"xmlns:xsi=\"{XsiNamespace}\"");
+        SchemaLocationValue(xml).ShouldBe(
+            IndexPair,
+            "a sitemapindex root validates against siteindex.xsd, not sitemap.xsd");
+    }
+
+    /// <summary>
+    /// The attribute value alternates namespace and schema tokens, whatever is attached.
+    /// </summary>
+    [TestMethod]
+    public void TheSchemaLocationValue_AlternatesNamespaceAndXsdTokens()
+    {
+        string xml = Save(SitemapWithEveryExtension(), OptionOn());
+
+        string[] tokens = SchemaLocationValue(xml)
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        tokens.Length.ShouldBeGreaterThan(0);
+        (tokens.Length % 2).ShouldBe(0, "the value must hold whole namespace/schema pairs");
+        for (int i = 1; i < tokens.Length; i += 2)
+        {
+            tokens[i].ShouldEndWith(".xsd", customMessage: $"token {i} must be a schema location");
+        }
+    }
+
+    /// <summary>
+    /// Output written with the option on still conforms to the sitemaps.org schemas.
+    /// </summary>
+    /// <remarks>
+    ///     The validator never processes <c>xsi:schemaLocation</c> — <c>ProcessSchemaLocation</c> is
+    ///     off in <see cref="ConformanceSchemas"/> — but the XSD specification permits the four
+    ///     <c>xsi:</c> attributes on any element without an <c>anyAttribute</c> declaration. This test
+    ///     proves that claim against the real validator rather than asserting it in prose. The presence
+    ///     assertion first keeps the test able to fail against a writer that writes nothing.
+    /// </remarks>
+    [TestMethod]
+    public void ASitemapWithTheSchemaLocationOn_StillConformsToTheSitemapsOrgSchema()
+    {
+        string plain = Save(PlainSitemap(), OptionOn());
+        string hreflang = Save(SitemapWithHreflang(), OptionOn());
+
+        SitemapIndex index = new();
+        index.Sitemaps.Add(new SitemapIndexEntry { Location = new Uri("https://example.com/sitemap.xml") });
+        string indexXml = Save(index, OptionOn());
+
+        SchemaLocationValue(plain).ShouldNotBeEmpty("the option is on, so the attribute must be present");
+        SchemaLocationValue(hreflang).ShouldNotBeEmpty();
+        SchemaLocationValue(indexXml).ShouldNotBeEmpty();
+
+        ConformanceSchemas.Describe(plain, ConformanceSchemas.Sitemap)
+            .ShouldBeEmpty("the xsi attributes made a plain sitemap invalid");
+        ConformanceSchemas.Describe(hreflang, ConformanceSchemas.Sitemap)
+            .ShouldBeEmpty("the xsi attributes made an hreflang sitemap invalid");
+        ConformanceSchemas.Describe(indexXml, ConformanceSchemas.Sitemap)
+            .ShouldBeEmpty("the xsi attributes made a sitemap index invalid");
+    }
+
+    /// <summary>
+    /// The default output carries no xsi attribute and no xsi declaration.
+    /// </summary>
+    /// <remarks>
+    ///     The pin on "the default output does not change". Proven able to fail by a scratch run with
+    ///     the default flipped to <see langword="true"/>; see the engineering log for issue 177.
+    /// </remarks>
+    [TestMethod]
+    public void ASitemapSavedWithDefaults_WritesNoXsiAttributes()
+    {
+        string xml = Save(SitemapWithEveryExtension(), new SyndicationResourceSaveSettings());
+
+        xml.ShouldNotContain("xsi");
+        xml.ShouldNotContain("schemaLocation");
+    }
+
+    private static SyndicationResourceSaveSettings OptionOn() => new() { WriteXsiSchemaLocation = true };
+
+    private static Syndication.Sitemap PlainSitemap()
+    {
+        Syndication.Sitemap sitemap = new();
+        sitemap.Urls.Add(new SitemapUrl(new Uri("https://example.com/")));
+        return sitemap;
+    }
+
+    private static Syndication.Sitemap SitemapWithNewsAndImages()
+    {
+        SitemapNewsExtension news = new()
+        {
+            Title = "A breaking story",
+            PublicationDate = new DateTime(2026, 8, 10, 9, 0, 0, DateTimeKind.Utc),
+            Publication = new SitemapNewsPublication { Name = "The Example Times", Language = "en" },
+        };
+
+        SitemapImageExtension images = new();
+        images.Images.Add(new SitemapImage { Location = new Uri("https://example.com/img/hero.jpg") });
+
+        SitemapUrl url = new(new Uri("https://example.com/news/story"));
+        url.Extensions.Add(news);
+        url.Extensions.Add(images);
+
+        Syndication.Sitemap sitemap = new();
+        sitemap.Urls.Add(url);
+        return sitemap;
+    }
+
+    private static Syndication.Sitemap SitemapWithVideo()
+    {
+        SitemapVideo video = new()
+        {
+            Title = "An example video",
+            Description = "A description of the example video",
+            ThumbnailLocation = new Uri("https://example.com/thumb.jpg"),
+            ContentLocation = new Uri("https://example.com/video.mp4"),
+        };
+
+        SitemapVideoExtension extension = new();
+        extension.Videos.Add(video);
+
+        SitemapUrl url = new(new Uri("https://example.com/watch/1"));
+        url.Extensions.Add(extension);
+
+        Syndication.Sitemap sitemap = new();
+        sitemap.Urls.Add(url);
+        return sitemap;
+    }
+
+    private static Syndication.Sitemap SitemapWithHreflang()
+    {
+        SitemapHreflangExtension hreflang = new();
+        hreflang.Links.Add(new SitemapHreflangLink { Hreflang = "en", Href = new Uri("https://example.com/") });
+        hreflang.Links.Add(new SitemapHreflangLink { Hreflang = "fr", Href = new Uri("https://example.fr/") });
+
+        SitemapUrl url = new(new Uri("https://example.com/"));
+        url.Extensions.Add(hreflang);
+
+        Syndication.Sitemap sitemap = new();
+        sitemap.Urls.Add(url);
+        return sitemap;
+    }
+
+    private static Syndication.Sitemap SitemapWithEveryExtension()
+    {
+        Syndication.Sitemap sitemap = SitemapWithNewsAndImages();
+        sitemap.Urls.Add(SitemapWithVideo().Urls[0]);
+        sitemap.Urls.Add(SitemapWithHreflang().Urls[0]);
+        return sitemap;
+    }
+
+    private static string Save(Syndication.Sitemap sitemap, SyndicationResourceSaveSettings settings)
+    {
+        using MemoryStream stream = new();
+        sitemap.Save(stream, settings);
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string Save(SitemapIndex index, SyndicationResourceSaveSettings settings)
+    {
+        using MemoryStream stream = new();
+        index.Save(stream, settings);
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string SchemaLocationValue(string xml)
+    {
+        using StringReader reader = new(xml.TrimStart('﻿'));
+        XPathDocument document = new(reader);
+        XPathNavigator navigator = document.CreateNavigator();
+        navigator.MoveToChild(XPathNodeType.Element).ShouldBeTrue("the document has no root element");
+        return navigator.GetAttribute("schemaLocation", XsiNamespace);
+    }
+}

--- a/Solutions/Argotic.Extensions/Core/Sitemap/SitemapExtensionUtility.cs
+++ b/Solutions/Argotic.Extensions/Core/Sitemap/SitemapExtensionUtility.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+
+namespace Argotic.Extensions.Core;
+
+/// <summary>
+/// Provides date formatting shared by the sitemap extension writers.
+/// </summary>
+internal static class SitemapExtensionUtility
+{
+    /// <summary>
+    /// Formats a date for a sitemap extension element, in UTC, with the <c>Z</c> designator.
+    /// </summary>
+    /// <param name="dateTime">The date to format. An <see cref="DateTimeKind.Unspecified"/> kind is a claim of UTC.</param>
+    /// <returns>The date in the form <c>2026-08-10T05:30:00Z</c>.</returns>
+    /// <remarks>
+    ///     <para>
+    ///     The writers used <c>zzz</c> here. On .NET 10, <c>zzz</c> writes <c>+00:00</c> for a
+    ///     <see cref="DateTimeKind.Utc"/> value on every machine, but it stamps the machine's own
+    ///     offset on a <see cref="DateTimeKind.Local"/> or <see cref="DateTimeKind.Unspecified"/> wall
+    ///     clock. The load paths parse with <c>AssumeUniversal | AdjustToUniversal</c>, so an
+    ///     Unspecified value written on a non-UTC machine came back as a different instant. This
+    ///     method normalises the kind first. The output is then identical on every machine.
+    ///     </para>
+    ///     <para>
+    ///     The kind must be normalised before the format call. The <c>K</c> specifier writes <c>Z</c>
+    ///     for a Utc kind, but it writes nothing for an Unspecified kind.
+    ///     </para>
+    ///     <para>
+    ///     This method does not share <c>SyndicationDateTimeUtility.ToRfc3339DateTime</c>. That method
+    ///     writes fractional seconds, and it keeps a numeric offset for a Local kind — both are
+    ///     correct for Atom, and both are forms issue 177 asks this writer to avoid.
+    ///     </para>
+    /// </remarks>
+    public static string ToSitemapDateTime(DateTime dateTime)
+    {
+        DateTime utc = dateTime.Kind switch
+        {
+            DateTimeKind.Local => dateTime.ToUniversalTime(),
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(dateTime, DateTimeKind.Utc),
+            _ => dateTime,
+        };
+
+        return utc.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ssK", CultureInfo.InvariantCulture);
+    }
+}

--- a/Solutions/Argotic.Extensions/Core/Sitemap/SitemapNewsExtension.cs
+++ b/Solutions/Argotic.Extensions/Core/Sitemap/SitemapNewsExtension.cs
@@ -59,7 +59,7 @@ public class SitemapNewsExtension : SyndicationExtension, IComparable<SitemapNew
     /// </value>
     /// <remarks>
     ///     Loading normalises to UTC, so the offset the publisher wrote is lost on a round-trip:
-    ///     <c>2024-01-15T10:00:00-05:00</c> is written back as <c>2024-01-15T15:00:00+00:00</c>. Same
+    ///     <c>2024-01-15T10:00:00-05:00</c> is written back as <c>2024-01-15T15:00:00Z</c>. Same
     ///     instant, different text, and Google accepts either.
     /// </remarks>
     public DateTime PublicationDate { get; set; } = DateTime.MinValue;
@@ -189,7 +189,7 @@ public class SitemapNewsExtension : SyndicationExtension, IComparable<SitemapNew
 
         if (this.PublicationDate != DateTime.MinValue)
         {
-            writer.WriteElementString("publication_date", this.XmlNamespace, this.PublicationDate.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture));
+            writer.WriteElementString("publication_date", this.XmlNamespace, SitemapExtensionUtility.ToSitemapDateTime(this.PublicationDate));
         }
 
         if (!string.IsNullOrEmpty(this.Title))

--- a/Solutions/Argotic.Extensions/Core/Sitemap/SitemapVideo.cs
+++ b/Solutions/Argotic.Extensions/Core/Sitemap/SitemapVideo.cs
@@ -307,7 +307,7 @@ public class SitemapVideo : IComparable<SitemapVideo>, IEquatable<SitemapVideo>,
     /// <value>The expiry instant, or <see langword="null"/> if the video does not expire.</value>
     /// <remarks>
     ///     Loading converts to UTC, so the offset a publisher wrote is not what a round-trip writes back —
-    ///     <c>2024-01-15T10:00:00-05:00</c> returns as <c>2024-01-15T15:00:00+00:00</c>. The instant is
+    ///     <c>2024-01-15T10:00:00-05:00</c> returns as <c>2024-01-15T15:00:00Z</c>. The instant is
     ///     preserved; the wall-clock text is not.
     /// </remarks>
     public DateTime? ExpirationDate { get; set; }
@@ -864,7 +864,7 @@ public class SitemapVideo : IComparable<SitemapVideo>, IEquatable<SitemapVideo>,
 
         if (this.ExpirationDate.HasValue)
         {
-            writer.WriteElementString("expiration_date", xmlNamespace, this.ExpirationDate.Value.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture));
+            writer.WriteElementString("expiration_date", xmlNamespace, SitemapExtensionUtility.ToSitemapDateTime(this.ExpirationDate.Value));
         }
 
         if (this.Rating.HasValue)
@@ -881,7 +881,7 @@ public class SitemapVideo : IComparable<SitemapVideo>, IEquatable<SitemapVideo>,
 
         if (this.PublicationDate.HasValue)
         {
-            writer.WriteElementString("publication_date", xmlNamespace, this.PublicationDate.Value.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture));
+            writer.WriteElementString("publication_date", xmlNamespace, SitemapExtensionUtility.ToSitemapDateTime(this.PublicationDate.Value));
         }
 
         // The remaining order is not a matter of taste: sitemap-video-1.1.xsd declares an xsd:sequence,


### PR DESCRIPTION
Closes #177. The two fixes ship together, as the issue asks.

## Task 1 — Sitemap extension dates write in UTC with the Z designator

- `news:publication_date`, `video:publication_date` and `video:expiration_date` used the format
  string `yyyy-MM-ddTHH:mm:sszzz`.
- The new internal helper `SitemapExtensionUtility.ToSitemapDateTime` normalises the kind first:
  `Local` converts to UTC, `Unspecified` is a claim of UTC and keeps its wall clock. Then it formats
  with the `K` specifier. The output is identical on every machine.
- **One correction to the issue text.** On .NET 10, `zzz` writes `+00:00` for a `Utc` kind on every
  machine. The runtime special-cases that kind. The issue's example (a `Utc` value shifts on a
  UTC+02:00 machine) does not occur. The real defect was the `Unspecified` kind: `zzz` stamped the
  machine offset on its wall clock, and the load path assumes UTC, so the instant shifted. The
  agreed fix is correct for all three kinds and is unchanged.

## Task 2 — Opt-in xsi:schemaLocation output

- New setting: `SyndicationResourceSaveSettings.WriteXsiSchemaLocation`. The default is `false`.
  The default output does not change.
- Three design points, agreed with the maintainer before implementation:
  - The option lives on the save settings, not on the `Sitemap` class. All save-time options live
    there.
  - `SitemapIndex.Save` honours the option too. Its root validates against `siteindex.xsd`, so the
    core pair is root-dependent.
  - A namespace with no known schema location is skipped: the hreflang extension's `xhtml`
    namespace, and consumer extensions. The XSD locations keep the `http` scheme of the protocol's
    examples.
- With the option on, the root element gets `xmlns:xsi` and one namespace/XSD pair for the core
  namespace, then one pair for each declared extension namespace with a published schema (news,
  image, video).

## Verification

- 21 new tests. Each was proven able to fail first: nine date tests ran red against unmodified
  code, eight schemaLocation tests ran red against the inert setting, and each pin ran red under a
  scratch edit that was then reverted.
- Full quality gate before each commit: Debug and Release builds with 0 warnings; offline suite at
  `succeeded: 3550`; both `dotnet format` gates; 204 of 204 examples; 21 of 21 samples.
- `TZ=Europe/Berlin` runs are green. The old code was only safe on a UTC host.
- Live conformance tier: 20 of 20, 0 skipped. Google's published schemas accept the corpus after a
  load-then-save rewrite with the new date form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)