### PR TITLE
Pin surrogate-pair survival across read-block boundaries at every block size

### DIFF
--- a/Solutions/Argotic.Extensions.Tests/Functionality/Common/SanitiserCharacterisationTests.cs
+++ b/Solutions/Argotic.Extensions.Tests/Functionality/Common/SanitiserCharacterisationTests.cs
@@ -269,6 +269,49 @@ public sealed class SanitiserCharacterisationTests
         }
     }
 
+    /// <summary>
+    /// Row 26 — a read-block boundary that divides a surrogate pair does not divide the character.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     The sanitising reader classifies a pair when it sees the high half, and when the caller's
+    ///     buffer fills between the halves the approved low half is held to the next call and emitted
+    ///     <i>verbatim</i>. Sending it through classification again would find a low surrogate with no
+    ///     high before it, drop it as unpaired, and hand the parser a lone high surrogate — a parse
+    ///     error manufactured out of a valid emoji.
+    ///     </para>
+    ///     <para>
+    ///     Rows 24 and 25 already catch this, but only because their offset brackets happen to
+    ///     straddle today's block size — measured by perturbing the reader to reclassify a held low
+    ///     half at the start of each read call, which turned exactly the four astral sweep cases red
+    ///     (issue #176 records the experiment). This row removes the dependency on any particular
+    ///     block size: the run is longer than any plausible read block, so every block length puts
+    ///     boundaries inside it, and of two runs that start one position apart, one must place a
+    ///     boundary between the halves of some pair whatever that length is.
+    ///     </para>
+    ///     <para>
+    ///     Full string equality, not length: equality also finds a dropped half, a substituted
+    ///     replacement character, and a reordering.
+    ///     </para>
+    /// </remarks>
+    [TestMethod]
+    public void ASurrogatePairDividedByAReadBlockBoundary_SurvivesIntact()
+    {
+        string run = string.Concat(Enumerable.Repeat("\U0001F600", 20_000));
+        string[] alignments = ["", "x"];
+
+        foreach (string prefix in alignments)
+        {
+            string document = string.Concat("<r>", prefix, run, "</r>");
+
+            foreach (string entryPoint in EntryPoints)
+            {
+                RootOf(Parse(entryPoint, document))
+                    .ShouldBe(document, $"{entryPoint}, run at offset {prefix.Length}");
+            }
+        }
+    }
+
     private static IEnumerable<int> Offsets()
     {
         for (int n = 1_000; n <= 1_050; n++)

--- a/Solutions/Argotic.Extensions.Tests/Functionality/Common/SanitiserCharacterisationTests.cs
+++ b/Solutions/Argotic.Extensions.Tests/Functionality/Common/SanitiserCharacterisationTests.cs
@@ -300,11 +300,15 @@ public sealed class SanitiserCharacterisationTests
         string run = string.Concat(Enumerable.Repeat("\U0001F600", 20_000));
         string[] alignments = ["", "x"];
 
+        // The shared list plus the explicit-encoding stream overload, so every public
+        // CreateSafeNavigator shape faces the boundary.
+        string[] entryPoints = [.. EntryPoints, "stream+encoding"];
+
         foreach (string prefix in alignments)
         {
             string document = string.Concat("<r>", prefix, run, "</r>");
 
-            foreach (string entryPoint in EntryPoints)
+            foreach (string entryPoint in entryPoints)
             {
                 RootOf(Parse(entryPoint, document))
                     .ShouldBe(document, $"{entryPoint}, run at offset {prefix.Length}");
@@ -349,6 +353,12 @@ public sealed class SanitiserCharacterisationTests
                     XPathNavigator navigator = SyndicationEncodingUtility.CreateSafeNavigator(reader);
                     reader.DisposeCount.ShouldBe(0, "nothing should dispose a reader it did not open");
                     return navigator;
+                }
+
+            case "stream+encoding":
+                using (MemoryStream stream = new(Encoding.UTF8.GetBytes(document), writable: false))
+                {
+                    return SyndicationEncodingUtility.CreateSafeNavigator(stream, Encoding.UTF8);
                 }
 
             default:


### PR DESCRIPTION
Issue #176 asked for a test that divides a surrogate pair at a read-block
boundary in XmlSanitizingTextReader, and for the gap analysis to be measured
before being believed. Measured, the analysis is refuted: branch coverage on
the reader is saturated (Fill 16/16, Read(Span) 4/4), and a mutation that
reclassifies a low half held across a Read-call boundary — the exact defect
the two-slot design prevents — turns four existing tests red, all of them the
astral arm of ADirtyCharacterAtEveryBufferBoundary_SanitisesIdentically,
failing at position 4097.

So the condition is exercised today, but only because the sweep's offset
brackets straddle today's 4,096-char block. The new row removes that
dependency: a run of 20,000 astral characters is longer than any plausible
read block, and of two runs starting one position apart, one must place a
block boundary between the halves of some pair whatever the block length is.
Asserted with full string equality through all four public entry points.

Verified per the issue's protocol: green against unmodified code, red under
the boundary mutation (1/1 failed), green again after revert; whole offline
suite 3,551/3,551.

Closes #176

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
