### PR TITLE
Drop the assembly version from the default RSS and APML generator strings

### DIFF
--- a/Solutions/Argotic.Core/Syndication/Apml/ApmlHead.cs
+++ b/Solutions/Argotic.Core/Syndication/Apml/ApmlHead.cs
@@ -66,7 +66,7 @@ public class ApmlHead : IComparable<ApmlHead>, IEquatable<ApmlHead>, IExtensible
     /// </summary>
     /// <value>The <c>Generator</c> element. It defaults to this framework's name and project URL, so a document saved without touching it credits Argotic.</value>
     /// <remarks>
-    ///     Deliberately version-free, for the same reason as <see cref="Syndication.RssChannel.Generator"/>:
+    ///     Deliberately version-free, for the same reason as <see cref="RssChannel.Generator"/>:
     ///     a version stamp in the default makes identical content serialize to different bytes across
     ///     package upgrades.
     /// </remarks>

--- a/Solutions/Argotic.Core/Syndication/Apml/ApmlHead.cs
+++ b/Solutions/Argotic.Core/Syndication/Apml/ApmlHead.cs
@@ -64,16 +64,17 @@ public class ApmlHead : IComparable<ApmlHead>, IEquatable<ApmlHead>, IExtensible
     /// <summary>
     /// Gets or sets a value that credits the software that created this document.
     /// </summary>
-    /// <value>The <c>Generator</c> element. It defaults to this framework's name, version and project URL, so a document saved without touching it credits Argotic.</value>
-    // Both null-forgiving operators in the default value are provable. Assembly.GetAssembly returns
-    // null only for a type with no backing assembly, which a typeof() of a type declared here cannot
-    // be, and AssemblyName.Version is always populated because the SDK emits an assembly version
-    // whether or not one is set explicitly.
+    /// <value>The <c>Generator</c> element. It defaults to this framework's name and project URL, so a document saved without touching it credits Argotic.</value>
+    /// <remarks>
+    ///     Deliberately version-free, for the same reason as <see cref="Syndication.RssChannel.Generator"/>:
+    ///     a version stamp in the default makes identical content serialize to different bytes across
+    ///     package upgrades.
+    /// </remarks>
     public string Generator
     {
         get;
         set => field = string.IsNullOrEmpty(value) ? string.Empty : value.Trim();
-    } = $"Argotic Syndication Framework {System.Reflection.Assembly.GetAssembly(typeof(ApmlHead))!.GetName().Version!.ToString(4)}, https://github.com/argotic-syndication-framework/argotic/";
+    } = "Argotic Syndication Framework, https://github.com/argotic-syndication-framework/argotic/";
 
     /// <summary>
     /// Gets or sets the title of this document.

--- a/Solutions/Argotic.Core/Syndication/Rss/RssChannel.cs
+++ b/Solutions/Argotic.Core/Syndication/Rss/RssChannel.cs
@@ -127,12 +127,18 @@ public class RssChannel : IComparable<RssChannel>, IEquatable<RssChannel>, IExte
     /// <summary>
     /// Gets or sets a value that credits the software that created this feed.
     /// </summary>
-    /// <value>The default value names this framework and its assembly version.</value>
+    /// <value>The default value names this framework and its project URL, and nothing else.</value>
+    /// <remarks>
+    ///     Deliberately version-free. The default used to embed the assembly version, which made
+    ///     <c>Save</c> produce different bytes for identical feed content on every package upgrade —
+    ///     invalidating any checksum a consumer stored over serialized output. A version is data about
+    ///     the software, not the feed; callers who want one can set this property themselves.
+    /// </remarks>
     public string Generator
     {
         get;
         set => field = value?.Trim() ?? string.Empty;
-    } = $"Argotic Syndication Framework {System.Reflection.Assembly.GetAssembly(typeof(RssChannel))?.GetName().Version?.ToString(4) ?? "unknown"}, https://github.com/argotic-syndication-framework/argotic/";
+    } = "Argotic Syndication Framework, https://github.com/argotic-syndication-framework/argotic/";
 
     /// <summary>
     /// Gets or sets the graphical logo for this feed.

--- a/Solutions/Argotic.Extensions.Tests/ExtensionTestUtil.cs
+++ b/Solutions/Argotic.Extensions.Tests/ExtensionTestUtil.cs
@@ -15,10 +15,10 @@ namespace Argotic.Extensions.Tests;
 ///     phrased, across 76 call sites.
 ///     </para>
 ///     <para>
-///     The wrapper interpolates the running assembly's version into the <c>generator</c> element rather
-///     than hard-coding one, because the library writes its own version there. A literal would make
-///     every one of those tests fail on the next version bump, for no reason connected to the extension
-///     under test.
+///     The <c>generator</c> element is a literal, because the library's default is now a fixed,
+///     version-free string (issue #179). It used to be interpolated from the running assembly's
+///     version to track the version the library stamped there — and only ever matched because the
+///     test and product assemblies happened to share a version number.
 ///     </para>
 /// </remarks>
 internal static class ExtensionTestUtil
@@ -71,7 +71,7 @@ internal static class ExtensionTestUtil
         return sw.ToString();
     }
 
-    private const string strFullXml1 = """<rss version="2.0" {0}><channel><title>Argotic - Extension Test</title><link>http://www.example.com/</link><description>Test of an extension</description><docs>https://www.rssboard.org/rss-specification</docs><generator>Argotic Syndication Framework {1}, https://github.com/argotic-syndication-framework/argotic/</generator><language>en-US</language><managingEditor>editor@example.com</managingEditor><webMaster>webmaster@example.com</webMaster><item><title>Item #1</title><description>text for First Item</description><link>http://www.example.com/item1.htm</link><pubDate>Sun, 01 Aug 2010 00:00:01 GMT</pubDate>{2}</item></channel></rss>""";
+    private const string strFullXml1 = """<rss version="2.0" {0}><channel><title>Argotic - Extension Test</title><link>http://www.example.com/</link><description>Test of an extension</description><docs>https://www.rssboard.org/rss-specification</docs><generator>Argotic Syndication Framework, https://github.com/argotic-syndication-framework/argotic/</generator><language>en-US</language><managingEditor>editor@example.com</managingEditor><webMaster>webmaster@example.com</webMaster><item><title>Item #1</title><description>text for First Item</description><link>http://www.example.com/item1.htm</link><pubDate>Sun, 01 Aug 2010 00:00:01 GMT</pubDate>{1}</item></channel></rss>""";
 
     private static readonly CompositeFormat FullXmlFormat = CompositeFormat.Parse(strFullXml1);
 
@@ -89,7 +89,7 @@ internal static class ExtensionTestUtil
     ///     <see cref="AddExtensionToXml"/>; as an input it is the document a load test parses, which is
     ///     why the extension elements are a parameter rather than a fixture.
     /// </remarks>
-    internal static string GetWrappedXml(string namespc, string strExt) => string.Format(CultureInfo.InvariantCulture, FullXmlFormat, namespc, typeof(ExtensionTestUtil).Assembly.GetName().Version?.ToString() ?? "0.0.0.0", strExt);
+    internal static string GetWrappedXml(string namespc, string strExt) => string.Format(CultureInfo.InvariantCulture, FullXmlFormat, namespc, strExt);
 
     private const string strFullAtomXml = """<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom" {0}><id>urn:example:feed</id><title>Argotic - Extension Test</title><updated>2010-08-01T00:00:01Z</updated><entry><id>urn:example:entry:1</id><title>Item #1</title><updated>2010-08-01T00:00:01Z</updated><summary>text for First Item</summary>{1}</entry></feed>""";
 

--- a/Solutions/Argotic.Extensions.Tests/Functionality/Core/Apml/ApmlDocumentTests.cs
+++ b/Solutions/Argotic.Extensions.Tests/Functionality/Core/Apml/ApmlDocumentTests.cs
@@ -46,6 +46,18 @@ public class ApmlDocumentTests
     }
 
     /// <summary>
+    /// The default generator credits the framework and nothing that changes between releases.
+    /// </summary>
+    /// <remarks>
+    ///     The same pin as the RSS channel's (issue #179): the default used to embed the assembly
+    ///     version, so a document saved with defaults changed bytes on every package upgrade.
+    /// </remarks>
+    [TestMethod]
+    public void Head_DefaultGenerator_CarriesNoAssemblyVersion()
+        => new ApmlHead().Generator.ShouldBe(
+            "Argotic Syndication Framework, https://github.com/argotic-syndication-framework/argotic/");
+
+    /// <summary>
     /// The name of the default profile is read back exactly as assigned.
     /// </summary>
     [TestMethod]

--- a/Solutions/Argotic.Extensions.Tests/Functionality/Core/Rss/RssFeedConstructionTests.cs
+++ b/Solutions/Argotic.Extensions.Tests/Functionality/Core/Rss/RssFeedConstructionTests.cs
@@ -228,6 +228,46 @@ public class RssFeedConstructionTests
         xml.ShouldContain("<item>");
     }
 
+    /// <summary>
+    /// The default generator credits the framework and nothing that changes between releases.
+    /// </summary>
+    /// <remarks>
+    ///     Pinned as the exact string, not a pattern, because the defect this guards against (issue
+    ///     #179) was a version stamp inside the default: identical feed content serialized to
+    ///     different bytes on every package upgrade, invalidating any checksum a consumer stored over
+    ///     saved output. Any reintroduced stamp — version, date, build metadata — fails this pin.
+    /// </remarks>
+    [TestMethod]
+    public void DefaultGenerator_CarriesNoAssemblyVersion()
+        => new RssChannel().Generator.ShouldBe(
+            "Argotic Syndication Framework, https://github.com/argotic-syndication-framework/argotic/");
+
+    /// <summary>
+    /// A feed saved without touching the generator writes the version-free default to the wire.
+    /// </summary>
+    [TestMethod]
+    public void Save_WithUntouchedGenerator_WritesTheVersionFreeDefault()
+    {
+        RssFeed feed = new()
+        {
+            Channel =
+            {
+                Title = "Test Feed",
+                Link = new Uri("http://example.com"),
+                Description = "Test feed description"
+            }
+        };
+
+        using MemoryStream stream = new();
+        feed.Save(stream);
+
+        stream.Position = 0;
+        using StreamReader reader = new(stream);
+        string xml = reader.ReadToEnd();
+
+        xml.ShouldContain("<generator>Argotic Syndication Framework, https://github.com/argotic-syndication-framework/argotic/</generator>");
+    }
+
     private static RssFeed CreateCompleteFeed()
     {
         RssFeed feed = new()


### PR DESCRIPTION
The default <generator> embedded the assembly version, so Save() produced
different bytes for identical feed content on every package upgrade — issue
#179's report, where every stored checksum over serialized output was
invalidated by a patch-level bump. Of the three resolutions the issue offers,
this takes the first: keep the attribution, remove the stamp. The default is
now the fixed string "Argotic Syndication Framework,
https://github.com/argotic-syndication-framework/argotic/" for both
RssChannel.Generator and ApmlHead.Generator, which carried the same defect.

An explicitly-set generator round-trips untouched, as before. The versioned
User-Agent strings in TrackbackClient and XmlRpcClient are HTTP headers, not
serialized output, and deliberately keep their versions.

The new tests pin the default as the exact string — any reintroduced stamp
fails the pin — and were proven red against the previous defaults before the
change was trusted. ExtensionTestUtil no longer interpolates the test
assembly's version into its expected XML, which only ever matched because the
test and product assemblies happened to share a version number.

The <docs> replacement noted in the issue is documented deliberate behaviour
(RssChannel.Documentation) and is left untouched.

Closes #179

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
